### PR TITLE
handle soft failure scenarios

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26366,6 +26366,13 @@ async function run() {
   try {
     const pingUrl = core2.getInput("ping-url");
     const uuid = core2.getState("uuid");
+    const runStatus = core2.getInput("run-status");
+    if (runStatus === "failure") {
+      core2.info(
+        "Run status is 'failure'. Failure ping will be sent in the post-step."
+      );
+      return;
+    }
     if (!pingUrl) {
       core2.setFailed("Ping URL is required.");
       return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -26367,6 +26367,12 @@ async function run() {
     const pingUrl = core2.getInput("ping-url");
     const uuid = core2.getState("uuid");
     const runStatus = core2.getInput("run-status");
+    if (runStatus !== "success" && runStatus !== "failure") {
+      core2.setFailed(
+        `Invalid run status: ${runStatus} - MUST be 'success' or 'failure'.`
+      );
+      return;
+    }
     if (runStatus === "failure") {
       core2.info(
         "Run status is 'failure'. Failure ping will be sent in the post-step."

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,13 @@ export async function run(): Promise<void> {
     const uuid = core.getState("uuid");
     const runStatus = core.getInput("run-status");
 
+    if (runStatus !== "success" && runStatus !== "failure") {
+      core.setFailed(
+        `Invalid run status: ${runStatus} - MUST be 'success' or 'failure'.`,
+      );
+      return;
+    }
+
     if (runStatus === "failure") {
       core.info(
         "Run status is 'failure'. Failure ping will be sent in the post-step.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,14 @@ export async function run(): Promise<void> {
   try {
     const pingUrl = core.getInput("ping-url");
     const uuid = core.getState("uuid");
+    const runStatus = core.getInput("run-status");
+
+    if (runStatus === "failure") {
+      core.info(
+        "Run status is 'failure'. Failure ping will be sent in the post-step.",
+      );
+      return;
+    }
 
     if (!pingUrl) {
       core.setFailed("Ping URL is required.");


### PR DESCRIPTION
This allows a user to send a failure signal even if the workflow does succeed. This is useful where the workflow does complete, but a condition within the workflow could be deemed as a failure but we don't hard fail (ie. non zero exit). 